### PR TITLE
Add honeycomb environment variables

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ processes = []
 
 [env]
   PORT = "8080"
+  HONEYCOMB_DATASET = "bemuse"
+  OTEL_SERVICE_NAME = "scoreboard"
 
 [experimental]
   allowed_public_ports = []


### PR DESCRIPTION
Note that this does not activate Honeycomb. To activate Honeycomb, run `flyctl secrets set HONEYCOMB_API_KEY=…`